### PR TITLE
Updated project to support dotnet6

### DIFF
--- a/dotSpace/BaseClasses/Network/EncoderBase.cs
+++ b/dotSpace/BaseClasses/Network/EncoderBase.cs
@@ -1,8 +1,7 @@
 ﻿using dotSpace.Interfaces;
 using dotSpace.Interfaces.Network;
 using System;
-using System.Web.Script.Serialization;
-
+using System.Text.Json;
 namespace dotSpace.BaseClasses.Network
 {
     /// <summary>
@@ -18,8 +17,7 @@ namespace dotSpace.BaseClasses.Network
         /// </summary>
         public T Deserialize<T>(string json, params Type[] types)
         {
-            JavaScriptSerializer serializer = new JavaScriptSerializer();
-            return serializer.Deserialize<T>(json);
+            return JsonSerializer.Deserialize<T>(json);
         }
 
         /// <summary>
@@ -27,8 +25,8 @@ namespace dotSpace.BaseClasses.Network
         /// </summary>
         public string Serialize(IMessage message, params Type[] types)
         {
-            JavaScriptSerializer serializer = new JavaScriptSerializer();
-            return serializer.Serialize(message);
+            // Why this works is a mystery to me, but the serializer didn't want to serialize the message when it was an interface.
+            return JsonSerializer.Serialize(Convert.ChangeType(message, message.GetType()));
         }
 
         /// <summary>

--- a/dotSpace/BaseClasses/Network/Messages/MessageBase.cs
+++ b/dotSpace/BaseClasses/Network/Messages/MessageBase.cs
@@ -2,7 +2,6 @@
 using dotSpace.Interfaces;
 using dotSpace.Interfaces.Network;
 using System;
-using System.Web.Script.Serialization;
 
 namespace dotSpace.BaseClasses.Network.Messages
 {
@@ -52,7 +51,6 @@ namespace dotSpace.BaseClasses.Network.Messages
         /// <summary>
         ///  Gets or sets the action to be executed by the remote space.
         /// </summary>
-        [ScriptIgnore]
         public ActionType Actiontype { get; set; }
         /// <summary>
         /// See Actiontype. Specified due to json.

--- a/dotSpace/Objects/Network/ResponseEncoder.cs
+++ b/dotSpace/Objects/Network/ResponseEncoder.cs
@@ -5,7 +5,6 @@ using dotSpace.Interfaces;
 using dotSpace.Interfaces.Network;
 using dotSpace.Objects.Json;
 using dotSpace.Objects.Network.Messages.Requests;
-
 namespace dotSpace.Objects.Network
 {
     /// <summary>

--- a/dotSpace/dotSpace.csproj
+++ b/dotSpace/dotSpace.csproj
@@ -1,127 +1,23 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{EA07D9C8-E59A-4C8F-BD98-1EC1EECD3351}</ProjectGuid>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>dotSpace</RootNamespace>
-    <AssemblyName>dotSpace</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\dotSpace.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\dotSpace.XML</DocumentationFile>
   </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject />
+  </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.Runtime.Serialization.Formatters.Soap" />
-    <Reference Include="System.Web.Extensions" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
+    <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.4.355802">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="BaseClasses\Space\AgentBase.cs" />
-    <Compile Include="BaseClasses\Network\Messages\RequestBase.cs" />
-    <Compile Include="BaseClasses\Network\Messages\ResponseBase.cs" />
-    <Compile Include="BaseClasses\Network\EncoderBase.cs" />
-    <Compile Include="BaseClasses\Network\GateBase.cs" />
-    <Compile Include="BaseClasses\Network\RepositoryBase.cs" />
-    <Compile Include="BaseClasses\Network\ConnectionModeBase.cs" />
-    <Compile Include="BaseClasses\Network\ProtocolBase.cs" />
-    <Compile Include="BaseClasses\Space\SpaceBase.cs" />
-    <Compile Include="Enumerations\Protocol.cs" />
-    <Compile Include="Enumerations\StatusCode.cs" />
-    <Compile Include="Interfaces\Space\ITupleFactory.cs" />
-    <Compile Include="Interfaces\Network\IOperationMap.cs" />
-    <Compile Include="Interfaces\Network\IConnectionMode.cs" />
-    <Compile Include="Interfaces\Network\IEncoder.cs" />
-    <Compile Include="Interfaces\Network\IGate.cs" />
-    <Compile Include="Interfaces\Network\IRepository.cs" />
-    <Compile Include="Interfaces\Network\IProtocol.cs" />
-    <Compile Include="Interfaces\Network\IMessage.cs" />
-    <Compile Include="Objects\Network\ConnectionModes\Pull.cs" />
-    <Compile Include="Objects\Network\Gates\GateFactory.cs" />
-    <Compile Include="Objects\Network\Protocols\Udp.cs" />
-    <Compile Include="Objects\Network\Gates\UdpGate.cs" />
-    <Compile Include="Objects\Space\PileSpace.cs" />
-    <Compile Include="Objects\Network\ConnectionModes\Keep.cs" />
-    <Compile Include="Objects\Network\Gates\TcpGate.cs" />
-    <Compile Include="Objects\Network\RemoteSpace.cs" />
-    <Compile Include="Objects\Network\Json\PatternValue.cs" />
-    <Compile Include="Objects\Network\Json\PatternBinding.cs" />
-    <Compile Include="Objects\Network\Json\TypeConverter.cs" />
-    <Compile Include="Objects\Network\Messages\Requests\QueryAllRequest.cs" />
-    <Compile Include="Objects\Network\Messages\Requests\GetPRequest.cs" />
-    <Compile Include="Objects\Network\Messages\Requests\GetAllRequest.cs" />
-    <Compile Include="Objects\Network\Messages\Requests\QueryPRequest.cs" />
-    <Compile Include="Objects\Network\Messages\Requests\QueryRequest.cs" />
-    <Compile Include="Objects\Network\Messages\Responses\QueryAllResponse.cs" />
-    <Compile Include="Objects\Network\Messages\Responses\GetPResponse.cs" />
-    <Compile Include="Objects\Network\Messages\Responses\GetAllResponse.cs" />
-    <Compile Include="Objects\Network\Messages\Responses\QueryPResponse.cs" />
-    <Compile Include="Objects\Network\Messages\Responses\QueryResponse.cs" />
-    <Compile Include="Objects\Network\ConnectionModes\Push.cs" />
-    <Compile Include="Objects\Network\ResponseEncoder.cs" />
-    <Compile Include="Objects\Network\RequestEncoder.cs" />
-    <Compile Include="Objects\Network\Messages\Responses\BasicResponse.cs" />
-    <Compile Include="Enumerations\Action.cs" />
-    <Compile Include="Enumerations\ConnectionMode.cs" />
-    <Compile Include="Interfaces\Space\IFields.cs" />
-    <Compile Include="Interfaces\Space\IPattern.cs" />
-    <Compile Include="Interfaces\Space\ITuple.cs" />
-    <Compile Include="Interfaces\Space\ISpace.cs" />
-    <Compile Include="BaseClasses\Network\Messages\MessageBase.cs" />
-    <Compile Include="Objects\Network\ConnectionModes\Conn.cs" />
-    <Compile Include="Objects\Network\Messages\Requests\GetRequest.cs" />
-    <Compile Include="Objects\Network\Messages\Responses\GetResponse.cs" />
-    <Compile Include="Objects\Network\Messages\Responses\PutResponse.cs" />
-    <Compile Include="Objects\Network\Messages\Requests\PutRequest.cs" />
-    <Compile Include="Objects\Network\Messages\Requests\BasicRequest.cs" />
-    <Compile Include="Objects\Network\SpaceRepository.cs" />
-    <Compile Include="Objects\Network\Protocols\Tcp.cs" />
-    <Compile Include="Objects\Space\Pattern.cs" />
-    <Compile Include="Objects\Space\TupleFactory.cs" />
-    <Compile Include="Objects\Utility\MessageQueue.cs" />
-    <Compile Include="Objects\Network\StatusMessage.cs" />
-    <Compile Include="Objects\Network\OperationMap.cs" />
-    <Compile Include="Objects\Space\Tuple.cs" />
-    <Compile Include="Objects\Space\SequentialSpace.cs" />
-    <Compile Include="Objects\Network\ConnectionString.cs" />
-    <Compile Include="Objects\Utility\ExtensionMethods.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>


### PR DESCRIPTION
The project previously used a JSON serializer from the System.Web.Script.Serialization namespace. The behaviour seems to have changed around .NETFramework 4.7.2 or so and should not be used.

I've changed the serializer to the one in System.Text.Json, but it seems like the project in general has been made with the old serializer in mind and the fix I've made should probably only be a temporary fix until a re-write of the serialization part can be made.